### PR TITLE
fix(auth): fix session cookie not set on Vercel

### DIFF
--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -1,5 +1,6 @@
 import { SESSION_COOKIE } from '~~/server/constants'
 import { createAdminClient } from '~~/server/lib/appwrite'
+import { getSessionCookieOptions } from '~~/server/lib/session-cookie'
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
@@ -17,14 +18,7 @@ export default defineEventHandler(async (event) => {
       password
     })
 
-    setCookie(event, SESSION_COOKIE, session.secret, {
-      expires: new Date(session.expire),
-      path: '/',
-      httpOnly: true,
-      secure: true,
-      sameSite: 'none',
-      domain: process.env.NUXT_APP_DOMAIN ? `.${process.env.NUXT_APP_DOMAIN}` : undefined
-    })
+    setCookie(event, SESSION_COOKIE, session.secret, getSessionCookieOptions(event, session))
 
     return { success: true }
   } catch {

--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -2,6 +2,7 @@ import { ID } from 'node-appwrite'
 
 import { SESSION_COOKIE } from '~~/server/constants'
 import { createAdminClient } from '~~/server/lib/appwrite'
+import { getSessionCookieOptions } from '~~/server/lib/session-cookie'
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
@@ -25,14 +26,7 @@ export default defineEventHandler(async (event) => {
       password
     })
 
-    setCookie(event, SESSION_COOKIE, session.secret, {
-      expires: new Date(session.expire),
-      path: '/',
-      httpOnly: true,
-      secure: true,
-      sameSite: 'none',
-      domain: process.env.NUXT_APP_DOMAIN ? `.${process.env.NUXT_APP_DOMAIN}` : undefined
-    })
+    setCookie(event, SESSION_COOKIE, session.secret, getSessionCookieOptions(event, session))
 
     return { success: true }
   } catch {

--- a/server/lib/session-cookie.ts
+++ b/server/lib/session-cookie.ts
@@ -1,0 +1,15 @@
+import type { H3Event } from 'h3'
+import { getRequestProtocol } from 'h3'
+import type { Models } from 'node-appwrite'
+
+export function getSessionCookieOptions(event: H3Event, session: Models.Session) {
+  const isHttps = getRequestProtocol(event) === 'https'
+
+  return {
+    path: '/',
+    httpOnly: true,
+    secure: isHttps,
+    sameSite: 'lax' as const,
+    expires: new Date(session.expire)
+  }
+}


### PR DESCRIPTION
Make Secure conditional on request protocol, use SameSite=Lax and drop domain attribute so appwrite_session cookie is accepted over HTTP locally and HTTPS on Vercel.