### PR TITLE
fix(auth): fail loudly when Appwrite session secret is unavailable

### DIFF
--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -18,6 +18,13 @@ export default defineEventHandler(async (event) => {
       password
     })
 
+    if (!session.secret) {
+      throw createError({
+        statusCode: 500,
+        statusMessage: 'Appwrite returned an empty session secret. Check that APPWRITE_KEY is configured.'
+      })
+    }
+
     setCookie(event, SESSION_COOKIE, session.secret, getSessionCookieOptions(event, session))
 
     return { success: true }

--- a/server/api/auth/register.post.ts
+++ b/server/api/auth/register.post.ts
@@ -26,6 +26,13 @@ export default defineEventHandler(async (event) => {
       password
     })
 
+    if (!session.secret) {
+      throw createError({
+        statusCode: 500,
+        statusMessage: 'Appwrite returned an empty session secret. Check that APPWRITE_KEY is configured.'
+      })
+    }
+
     setCookie(event, SESSION_COOKIE, session.secret, getSessionCookieOptions(event, session))
 
     return { success: true }

--- a/server/lib/appwrite.ts
+++ b/server/lib/appwrite.ts
@@ -4,10 +4,17 @@ import { Account, Client, Storage, TablesDB } from 'node-appwrite'
 import { SESSION_COOKIE } from '../constants'
 
 export function createAdminClient() {
-  const client = new Client()
-    .setEndpoint(process.env.NUXT_PUBLIC_APPWRITE_ENDPOINT!)
-    .setProject(process.env.NUXT_PUBLIC_APPWRITE_PROJECT!)
-    .setKey(process.env.APPWRITE_KEY!)
+  const endpoint = process.env.NUXT_PUBLIC_APPWRITE_ENDPOINT
+  const project = process.env.NUXT_PUBLIC_APPWRITE_PROJECT
+  const key = process.env.APPWRITE_KEY
+
+  if (!endpoint || !project || !key) {
+    throw new Error(
+      'Appwrite env vars are missing on the server (NUXT_PUBLIC_APPWRITE_ENDPOINT, NUXT_PUBLIC_APPWRITE_PROJECT, APPWRITE_KEY)'
+    )
+  }
+
+  const client = new Client().setEndpoint(endpoint).setProject(project).setKey(key)
 
   return {
     get account() {


### PR DESCRIPTION
createAdminClient throws when server env vars are missing, and auth routes return a clear 500 when Appwrite responds with an empty session secret (e.g. malformed APPWRITE_KEY), instead of setting an empty cookie.