### PR TITLE
fix(auth): set session cookie domain to overwrite stale empty cookie

### DIFF
--- a/server/api/auth/logout.delete.ts
+++ b/server/api/auth/logout.delete.ts
@@ -1,5 +1,6 @@
 import { SESSION_COOKIE } from '~~/server/constants'
 import { createSessionClient } from '~~/server/lib/appwrite'
+import { getSessionCookieDomain } from '~~/server/lib/session-cookie'
 
 export default defineEventHandler(async (event) => {
   const { account } = createSessionClient(event)
@@ -10,7 +11,7 @@ export default defineEventHandler(async (event) => {
     // Session might already be invalid — still clear the cookie
   }
 
-  deleteCookie(event, SESSION_COOKIE, { path: '/' })
+  deleteCookie(event, SESSION_COOKIE, { path: '/', domain: getSessionCookieDomain() })
 
   return { success: true }
 })

--- a/server/lib/session-cookie.ts
+++ b/server/lib/session-cookie.ts
@@ -10,6 +10,12 @@ export function getSessionCookieOptions(event: H3Event, session: Models.Session)
     httpOnly: true,
     secure: isHttps,
     sameSite: 'lax' as const,
+    domain: getSessionCookieDomain(),
     expires: new Date(session.expire)
   }
+}
+
+export function getSessionCookieDomain() {
+  const domain = process.env.NUXT_APP_DOMAIN
+  return domain ? domain.replace(/^\./, '') : undefined
 }


### PR DESCRIPTION
Restore the Domain attribute from NUXT_APP_DOMAIN so the valid cookie replaces the empty appwrite_session=; Domain=... cookie left by the broken deployment instead of coexisting with it and breaking auth.